### PR TITLE
Path error on windows fixed

### DIFF
--- a/aoc_tiles/make_tiles.py
+++ b/aoc_tiles/make_tiles.py
@@ -140,7 +140,7 @@ class TileMaker:
 
         for day, future in day_to_future.items():
             tile_path, solution_path = future.result()
-            with html.tag("a", href=str(solution_path)):
+            with html.tag("a", href=str(solution_path.as_posix())):
                 html.tag("img", closing=False, src=tile_path.as_posix(), width=self.config.tile_width_px)
 
         # with open(completed_cache_path, "w") as file:


### PR DESCRIPTION
Hi, 

finally got it working to debug locally (weirdly I had to rename the html.py file locally, as it yielded an "ImportError: cannot import name 'escape' from 'html'" for the rich package). I think I found the cause for the path problems I mentioned on reddit, the HTML a tag did not receive a posix path, so the regex was not valid and yielded a bad escape sequence.