### PR TITLE
fixed none error if previous days have no solution

### DIFF
--- a/aoc_tiles/make_tiles.py
+++ b/aoc_tiles/make_tiles.py
@@ -140,7 +140,13 @@ class TileMaker:
 
         for day, future in day_to_future.items():
             tile_path, solution_path = future.result()
-            with html.tag("a", href=str(solution_path.as_posix())):
+            
+            if solution_path is None:
+                sol_path = str(solution_path)
+            else:
+                sol_path = str(solution_path.as_posix())
+
+            with html.tag("a", href=sol_path):
                 html.tag("img", closing=False, src=tile_path.as_posix(), width=self.config.tile_width_px)
 
         # with open(completed_cache_path, "w") as file:


### PR DESCRIPTION
Hi, 

while setting this addon up with a friend we noticed that if there are solutions missing in between days (e.g. day 13 is solved but none of the prior days) the addon crashes because the solution_path is then None. This is a case I didn't catch with the previous path error fix, so now it should work properly and generate tiles for not solved solutions. I am very sorry for this. 

Additionally we found that sometimes the caching of the leaderboard might fail. This is the case when the addon runs with an error but manages to create the leaderboardYEAR.html file but there is no content fetched. Then the hook will crash with the "No leaderboard found?!" assertion. 