### PR TITLE
Bug Fix -- count-as-solved-when option='either'

### DIFF
--- a/aoc_tiles/drawer.py
+++ b/aoc_tiles/drawer.py
@@ -77,17 +77,17 @@ class TileDrawer:
             if stars >= part:
                 draw_text((104, -5 + y), f"P{part} ", align="left", font=main_font(25))
 
-                if self.config.what_to_show_on_right_side == "checkmark":
+                if self.config.what_to_show_on_right_side == "checkmark" or day_scores is None:
                     draw_line((160, 35 + y, 150, 25 + y))
                     draw_line((160, 35 + y, 180, 15 + y))
 
-                if self.config.what_to_show_on_right_side == "time_and_rank":
+                elif self.config.what_to_show_on_right_side == "time_and_rank":
                     draw_text((105, 25 + y), "time", align="right", font=secondary_font(10))
                     draw_text((105, 35 + y), "rank", align="right", font=secondary_font(10))
                     draw_text((143, 3 + y), format_time(time), align="right", font=secondary_font(18))
                     draw_text((133, 23 + y), f"{rank:>6}", align="right", font=secondary_font(18))
 
-                if self.config.what_to_show_on_right_side == "loc":
+                elif self.config.what_to_show_on_right_side == "loc":
                     raise NotImplementedError("loc is not implemented yet")
 
             else:


### PR DESCRIPTION
Hi, thanks for aoc-tiles, I love it!

I've found some bugs with the count-as-solved-when options so thought it would be useful to submit fixes via pull requests.

I'm new to git-hub pull requests so appreciate any feedback on the best way to go about this.

**Bug description:**
'either' option of count-as-solved-when errors in the situation when there is a file for a day but the day hasn't been completed yet on the leaderboard. It fails because it tries format the time but it was provided as None.

**Fix**:
When rendering the tile, check that the time/score from the leaderboard has been supplied. If its None, default to the checkmark method.

aoc-tiles now works for me using the tests for the 2022 year (which I've only completed days 1-5 but there are files for all 25 days in the test folder)
