### PR TITLE
Bug fix: count-as-solved-when "on_leaderboard" option fix

### DIFF
--- a/aoc_tiles/make_tiles.py
+++ b/aoc_tiles/make_tiles.py
@@ -47,14 +47,8 @@ class TileMaker:
         }[self.config.count_as_solved_when]
 
     def compose_solve_data(self) -> SolveData:
-        is_solution_paths_needed = self.config.what_to_show_on_right_side in [
-            "loc"
-        ] or self.config.count_as_solved_when in ["file_exists", "both", "either"]
-        solution_paths_by_year = {}
-        years = []
-        if is_solution_paths_needed:
-            solution_paths_by_year = self.solution_finder.get_solution_paths_by_year(self.config.aoc_dir)
-            years = solution_paths_by_year.keys()
+        solution_paths_by_year = self.solution_finder.get_solution_paths_by_year(self.config.aoc_dir)
+        years = solution_paths_by_year.keys()
 
         is_leaderboard_needed = self.config.what_to_show_on_right_side in [
             "time_and_rank"


### PR DESCRIPTION
**Bug description**:
When the 'on_leaderboard' option is chosen at the moment, aoc-tiles will not generate any tiles. This is because the compose_solve_data function will skip the get_solution_paths_by_year step if the option is set to 'on_leaderboard'.

The problem with this is that the get_solution_paths_by_year step is how the function determines which years to download leaderboards for. So since this is skipped for 'on_leaderboard' this means that no years are found, and as such no leaderboards are downloaded.

**Fix**:
Remove the check 'is_solution_paths_needed' since solutions paths by year is needed for 'on_leaderboard' option as well.

An alternative fix would be to go through each possible year and check if there are any completed leaderboard positions for that year.

I think it's fine to rely on the solution paths since aoc-tiles is a tool for aoc repos, which means you would expect there to be at least some solution files.

This is also my preferred behaviour, where I want it to show tiles for days I've actually completed on the leaderboard, even if I don't have the solution in the repo yet (I complete many AOC days as part of a work event, where we have an internal repo to store solutions). I also prefer it to exclude days I've not yet completed but are work in progress in my repo (hence why I don't prefer the either option)